### PR TITLE
Update LoopCoreConstants.swift Default carb absorption times customization

### DIFF
--- a/LoopCore/LoopCoreConstants.swift
+++ b/LoopCore/LoopCoreConstants.swift
@@ -16,7 +16,7 @@ public enum LoopCoreConstants {
     /// The amount of time in the future a glucose value should be considered valid
     public static let futureGlucoseDataInterval = TimeInterval(minutes: 5)
 
-    public static let defaultCarbAbsorptionTimes: CarbStore.DefaultAbsorptionTimes = (fast: .minutes(30), medium: .hours(3), slow: .hours(5))
+    public static let defaultCarbAbsorptionTimes: CarbStore.DefaultAbsorptionTimes = (fast: .minutes(30), medium: .hours(1), slow: .hours(2))
 
     /// How much historical glucose to include in a dosing decision
     /// Somewhat arbitrary, but typical maximum visible in bolus glucose preview


### PR DESCRIPTION
Change default carb absorption times medium = 1hr, slow=2hrs. Fast remains at 30min